### PR TITLE
fix: 反链正则匹配时按思源版本逻辑移除 .sy 后缀

### DIFF
--- a/src/utils/docSortUtils.ts
+++ b/src/utils/docSortUtils.ts
@@ -2,6 +2,7 @@ import { debugPush, errorPush, logPush, warnPush } from "@/logger";
 import { getReadOnlyGSettings } from "@/manager/settingManager";
 import { isBlankStr, isValidStr } from "./commonCheck";
 import { LINK_SORT_TYPES } from "@/constants";
+import { trimListDocsByPathAPIReturnedDocName } from "@/utils/onlyThisUtil";
 import natsort from "natsort";
 
 export function removeDocByDocName(docList: IFile[], regExpStrList: string[]) {
@@ -12,7 +13,7 @@ export function removeDocByDocName(docList: IFile[], regExpStrList: string[]) {
         for (let reg of regExpList) {
             // 全局匹配g或粘性匹配y后，再次test从上次匹配位置之后开始匹配，这里清空
             reg.lastIndex = 0;
-            if (reg.test(doc.name.slice(0, -3))) {
+            if (reg.test(trimListDocsByPathAPIReturnedDocName(doc.name))) {
                 isRemove = true;
                 break;
             }
@@ -26,8 +27,8 @@ export function removeDocByDocName(docList: IFile[], regExpStrList: string[]) {
 
 /**
  * 根据正则字符串，将匹配的文档固定在列表前部
- * @param docList 请注意 文档名称以.sy结尾！匹配时会移除
- * @param regExpStrList 
+ * @param docList 文档名称可能以.sy结尾；匹配时会按需移除
+ * @param regExpStrList
  */
 export function pinDocByDocName(docList: IFile[], regExpStrList: string[]) {
     let regExpList = regExpStrList.map(turnRegStr2Reg).filter(reg => reg != null);
@@ -39,7 +40,7 @@ export function pinDocByDocName(docList: IFile[], regExpStrList: string[]) {
         for (let [index, doc] of docList.entries()) {
             // 全局匹配g或粘性匹配y后，再次test从上次匹配位置之后开始匹配，这里清空
             reg.lastIndex = 0;
-            if (reg.test(doc.name.slice(0, -3)) && !addedFlagList[index]) {
+            if (reg.test(trimListDocsByPathAPIReturnedDocName(doc.name)) && !addedFlagList[index]) {
                 pinDocList.push(doc);
                 addedFlagList[docList.indexOf(doc)] = true;
             }


### PR DESCRIPTION
## 问题

在反向链接的排除/置顶正则匹配中，原代码无条件对文档名执行 `slice(0, -3)`，假设所有名称都以 `.sy` 结尾。

但在思源 3.6.5+ 中，部分文档名 API 返回的名称已不再包含 `.sy` 后缀。这导致类似 `20220326 Sat` 的文档名被错误截断为 `20220326 `，使得正则 `^\d{8}\s+\w{3}\s*$` 无法命中，排除/置顶失效。

## 修改

- 改用项目已有的 `trimListDocsByPathAPIReturnedDocName` 工具函数处理文档名。
- 该函数会根据当前思源版本判断是否需要移除 `.sy` 后缀，保持与项目其他位置的处理逻辑一致。
- `removeDocByDocName` 和 `pinDocByDocName` 均使用该函数进行名称预处理。
- 同步更新 `pinDocByDocName` 的 JSDoc 注释。

## 关联

https://github.com/OpaqueGlass/syplugin-hierarchyNavigate/issues/64